### PR TITLE
Plugin Updates for Node version, Hapi best practices, and style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,css,json}]
+charset = utf-8
+
+# 4 space indentation
+[*.js]
+indent_style = space
+indent_size = 4
+
+# Matches the exact files either package.json or .travis.yml
+[*.{json}]
+indent_style = space
+indent_size = 2

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 
 node_js:
-  - 0.10
+  - 4.0

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Example configuration:
   register: require('hapi-api-versioning'),
   options: {
     defaultVersion: '1',
-    vendor: 'github' //your company
+    vendor: 'github' // your company
   }
 }
 
-//accessible in the handler
+// accessible in the handler
 request.pre.apiVersion
 
 ```

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: 4.0

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,29 +4,39 @@ http://tools.ietf.org/html/rfc4288#section-3.2
 Example: application/vnd.<company>[.version].param[+json]
 */
 
+// Load libraries
+
+const Joi = require('joi');
+
 // Declare internals
-var internals = {};
+
+const internals = {
+    schema: Joi.object({
+        vendor: Joi.string().required(),
+        defaultVersion: Joi.number().positive().required()
+    })
+};
+
 
 exports.register = function (server, options, next) {
-  server.ext('onPreHandler', [
-    function (request, reply) {
 
-      var acceptHeader = request.headers.accept;
-      var regex = new RegExp('^application\\/vnd\\.' + options.vendor + '\\.v(\\d+)');
-      var match = ( acceptHeader ? acceptHeader.match(regex) : null );
+    const regex = new RegExp(`^application\\/vnd\\.${options.vendor}\\.v(\\d+)`);
+    options = Joi.attempt(options, internals.schema, 'Plugin options do not match schema');
 
-      var apiVersion = options.defaultVersion;
-      if (match !== null) {
-        apiVersion = parseInt(match[1]);
-      }
+    server.ext('onPreHandler', (request, reply) => {
 
-      request.pre.apiVersion = apiVersion;
+        const acceptHeader = request.headers.accept;
+        const match = acceptHeader ? acceptHeader.match(regex) : null;
+        const apiVersion = match ? parseInt(match[1], 10) : options.defaultVersion;
 
-      return reply.continue();
-    }
-  ]);
-  next();
+        request.pre.apiVersion = apiVersion;
+
+        return reply.continue();
+    });
+
+    return next();
 };
+
 
 exports.register.attributes = {
     pkg: require('../package.json')

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "hapi-api-versioning",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Media type approach to versioning your api",
   "main": "index.js",
   "directories": {
     "test": "test"
   },
   "scripts": {
-    "test": "lab"
+    "test": "./node_modules/lab/bin/lab -a code -v -t 100 -L"
   },
   "repository": {
     "type": "git",
@@ -19,6 +19,10 @@
     "versioning",
     "api"
   ],
+  "engines": {
+    "node": ">=4.0",
+    "npm": ">=2.0"
+  },
   "peerDependencies": {
     "hapi": ">=8.x.x"
   },
@@ -32,5 +36,8 @@
   "bugs": {
     "url": "https://github.com/StarpTech/hapi-api-versioning/issues"
   },
-  "homepage": "https://github.com/StarpTech/hapi-api-versioning"
+  "homepage": "https://github.com/StarpTech/hapi-api-versioning",
+  "dependencies": {
+    "joi": "^7.2.3"
+  }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,52 +1,52 @@
 // Load modules
 
-var Code = require('code');
-var Hapi = require('hapi');
-var Lab = require('lab');
+const Code = require('code');
+const Hapi = require('hapi');
+const Lab = require('lab');
 
 
 // Declare internals
 
-var internals = {};
+const internals = {
+    plugin: {
+        register: require('../'),
+        options: {
+            defaultVersion: 1,
+            vendor: 'github'
+        }
+    }
+};
 
 
 // Test shortcuts
 
-var lab = exports.lab = Lab.script();
-var describe = lab.describe;
-var it = lab.it;
-var expect = Code.expect;
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
 
 
-describe('Scarecrow', function () {
+describe('Scarecrow', () => {
 
-    it('request with a specific api version', function (done) {
+    it('request with a specific api version', (done) => {
 
-        var server = new Hapi.Server();
+        const server = new Hapi.Server();
         server.connection();
 
-        var plugin = {
-          register: require('../'),
-          options: {
-            defaultVersion: 1,
-            vendor: 'github'
-          }
-        };
-
-        server.register(plugin, function (err) {
+        server.register(internals.plugin, (err) => {
 
             // Add test route
 
             server.route({
-              path: '/apiVersion',
-              method: 'GET',
-              handler: function (request, reply) {
-                expect(request.pre.apiVersion).to.equal(2);
-                return reply();
-              }
+                path: '/apiVersion',
+                method: 'GET',
+                handler: (request, reply) => {
+                    expect(request.pre.apiVersion).to.equal(2);
+                    return reply();
+                }
             });
 
-            var req = {
+            const req = {
                 method: 'GET',
                 url: 'http://example.com/apiVersion',
                 headers: {
@@ -54,39 +54,33 @@ describe('Scarecrow', function () {
                 }
             };
 
-            server.inject(req, function (res) {
-                done();
+            server.inject(req, (res) => {
+
+                return done();
             });
         });
     });
 
-    it('Request with an invalid api version should fallback to default version', function (done) {
+    it('Request with an invalid api version should fallback to default version', (done) => {
 
-        var server = new Hapi.Server();
+        const server = new Hapi.Server();
         server.connection();
 
-        var plugin = {
-          register: require('../'),
-          options: {
-            defaultVersion: 1,
-            vendor: 'github'
-          }
-        };
+        server.register(internals.plugin, (err) => {
 
-        server.register(plugin, function (err) {
+            // Add test route
 
-          // Add test route
+            server.route({
+                path: '/apiVersion',
+                method: 'GET',
+                handler: (request, reply) => {
 
-          server.route({
-            path: '/apiVersion',
-            method: 'GET',
-            handler: function (request, reply) {
-              expect(request.pre.apiVersion).to.equal(1);
-              return reply();
-            }
-          });
+                    expect(request.pre.apiVersion).to.equal(1);
+                    return reply();
+                }
+            });
 
-            var req = {
+            const req = {
                 method: 'GET',
                 url: 'http://example.com/apiVersion',
                 headers: {
@@ -94,77 +88,65 @@ describe('Scarecrow', function () {
                 }
             };
 
-            server.inject(req, function (res) {
+            server.inject(req, (res) => {
+
                 done();
             });
         });
     });
 
-    it('None accept header should fallback to default version', function (done) {
+    it('None accept header should fallback to default version', (done) => {
 
-        var server = new Hapi.Server();
+        const server = new Hapi.Server();
         server.connection();
 
-        var plugin = {
-          register: require('../'),
-          options: {
-            defaultVersion: 1,
-            vendor: 'github'
-          }
-        };
+        server.register(internals.plugin, (err) => {
 
-        server.register(plugin, function (err) {
+            // Add test route
 
-          // Add test route
+            server.route({
+                path: '/apiVersion',
+                method: 'GET',
+                handler: (request, reply) => {
 
-          server.route({
-            path: '/apiVersion',
-            method: 'GET',
-            handler: function (request, reply) {
-              expect(request.pre.apiVersion).to.equal(1);
-              return reply();
-            }
-          });
+                    expect(request.pre.apiVersion).to.equal(1);
+                    return reply();
+                }
+            });
 
-            var req = {
+            const req = {
                 method: 'GET',
                 url: 'http://example.com/apiVersion',
                 headers: {}
             };
 
-            server.inject(req, function (res) {
-                done();
+            server.inject(req, (res) => {
+
+                return done();
             });
         });
     });
 
-    it('request with a specific two or more digit api version', function (done) {
+    it('request with a specific two or more digit api version', (done) => {
 
-        var server = new Hapi.Server();
+        const server = new Hapi.Server();
         server.connection();
 
-        var plugin = {
-          register: require('../'),
-          options: {
-            defaultVersion: 1,
-            vendor: 'github'
-          }
-        };
+        server.register(internals.plugin, (err) => {
 
-        server.register(plugin, function (err) {
+            // Add test route
 
-          // Add test route
+            server.route({
+                path: '/apiVersion',
+                method: 'GET',
+                handler: (request, reply) => {
 
-          server.route({
-            path: '/apiVersion',
-            method: 'GET',
-            handler: function (request, reply) {
-              expect(request.pre.apiVersion).to.equal(321);
-              return reply();
-            }
-          });
+                    expect(request.pre.apiVersion).to.equal(321);
+                    return reply();
+                }
+            });
 
-            var req = {
+            const req = {
                 method: 'GET',
                 url: 'http://example.com/apiVersion',
                 headers: {
@@ -172,8 +154,9 @@ describe('Scarecrow', function () {
                 }
             };
 
-            server.inject(req, function (res) {
-                done();
+            server.inject(req, (res) => {
+
+                return done();
             });
         });
     });


### PR DESCRIPTION
- Added Joi plugin schema support for defaultValue and vendor
- Added Engine section to package.json for Node version >4.x
- Added more strict version of lab run with `npm test` for code coverage and linting
- Fixed style issues with plugin and tests
- Added .editorconfig to help with Hapi style guide issues moving forward
  http://hapijs.com/styleguide
- Updated to ES2015 conventions in accordance with Hapi 11.x Style Guide
- Moved Regex into Plugin registration so it's not defined on each call to `onPreHandler`
